### PR TITLE
allow reading `$HOME/.ssh` by default

### DIFF
--- a/com.gitbutler.gitbutler.yml
+++ b/com.gitbutler.gitbutler.yml
@@ -7,10 +7,9 @@ finish-args:
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland
-  - --talk-name=org.freedesktop.Notifications
   - --device=dri
   - --share=network
-  - --filesystem=host
+  - --filesystem=~/.ssh:ro
   - --filesystem=xdg-run/gvfsd
 modules:
   - name: webkit2gtk-4.0


### PR DESCRIPTION
Allow reading of `HOME/.ssh` only by default. 

Other directories can be accessed via a portal.